### PR TITLE
update regular expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ Please change it in ${__dirname}/package.json
   ~ xoxo, bones
 ********************************************************************`
 
-const reasonableName = /^[[a-z0-9]\-?]*$/
+const reasonableName = /^[a-z0-9_\-]+$/
 if (!reasonableName.test(pkg.name)) {
   console.error(chalk.red(nameError))
 }

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ Please change it in ${__dirname}/package.json
   ~ xoxo, bones
 ********************************************************************`
 
-const reasonableName = /^[[a-z0-9]\-]+$/
+const reasonableName = /^[[a-z0-9]\-?]*$/
 if (!reasonableName.test(pkg.name)) {
   console.error(chalk.red(nameError))
 }


### PR DESCRIPTION
With `/^[[a-z0-9]\-]+$/`, the package name needs to be a hyphenated word (ex. "bones-app") but the check would fail if the app name was a single word (like "bones"). 

Modified to `/^[[a-z0-9]\-?]*$/`, to make the hyphenation optional.

Tested:

```
const exp = /[[a-z0-9]\-?]*$/
exp.test('')                // false
exp.test('__BONES__')       // false
exp.test('bones')           // true
exp.test('bones-app')       // true
```
